### PR TITLE
Use conn.params instead of raw request body as "data".

### DIFF
--- a/lib/exsentry/model/request.ex
+++ b/lib/exsentry/model/request.ex
@@ -20,7 +20,12 @@ defmodule ExSentry.Model.Request do
   """
   @spec from_conn(%Plug.Conn{}) :: %ExSentry.Model.Request{}
   def from_conn(conn) do
-    {:ok, data, _conn} = Plug.Conn.read_body(conn, length: 8192)
+    data = case conn.params do
+             %Plug.Conn.Unfetched{} ->
+               nil
+             params ->
+               params
+           end
     headers = conn.req_headers |> ExSentry.Utils.merge_http_headers
     cookies = case conn.req_cookies do
                 %Plug.Conn.Unfetched{} ->


### PR DESCRIPTION
`Plug.Conn.read_body` [will only work once, as Plug will not cache the result of these operations.](https://github.com/elixir-lang/plug/blob/v1.1.3/lib/plug/conn.ex#L670-L674) Thus if the body has already been fetched (e.g. by `Plug.Parsers`), the result of this call will be an empty string.
