### PR TITLE
Disable sender config option

### DIFF
--- a/lib/exsentry.ex
+++ b/lib/exsentry.ex
@@ -26,7 +26,15 @@ defmodule ExSentry do
   3. Optional: To configure the default ExSentry client, specify your
      Sentry DSN in `config.exs`:
 
-          config :exsentry, dsn: "your-dsn-here"
+          config :exsentry,
+            dsn: "your-dsn-here",
+            sender_opts: [ # this section optional
+              disabled: false, # stops sending to sentry
+              delay: 1000, # delay between retries
+              timeout: 3000, # http timeout for sentry post
+              retries: 3,
+              logging: true, # everything sent to Sentry is also logged w/ Logger
+            ]
 
 
   ## Usage

--- a/lib/exsentry/client.ex
+++ b/lib/exsentry/client.ex
@@ -133,8 +133,10 @@ defmodule ExSentry.Client do
         {"Content-Type", "application/json"}
       ]
       sender_opts = Application.get_env(:exsentry, :sender_opts) || %{}
-      {:ok, pid} = GenServer.start_link(ExSentry.Sender, sender_opts)
-      ExSentry.Sender.send_request(pid, state.url, headers, stripped_payload)
+      unless sender_opts[:disabled] do
+        {:ok, pid} = GenServer.start_link(ExSentry.Sender, sender_opts)
+        ExSentry.Sender.send_request(pid, state.url, headers, stripped_payload)
+      end
     end
   end
 

--- a/test/exsentry/client_test.exs
+++ b/test/exsentry/client_test.exs
@@ -25,6 +25,32 @@ defmodule ExSentry.ClientTest do
         end
       end
     end
+
+    context "when send is disabled" do
+      it "skips sending the request" do
+        with_mock Application, [:passthrough], [
+          get_env: fn(:exsentry, :sender_opts) -> %{disabled: true} end
+        ] do
+          with_mock ExSentry.Sender, [:passthrough], [
+            init: fn (_) -> {:ok, :whatever} end,
+            send_request: fn (_pid, _url, _headers, _payload) ->
+              raise "This shouldn't be called"
+            end
+          ] do
+            with_mock GenServer, [:passthrough], [
+              start_link: fn (ExSentry.Sender, _) -> raise "This shouldn't be called" end,
+            ] do
+              try do
+                raise "hey"
+              rescue
+                e ->
+                  capture_exception(e, System.stacktrace, [], %State{})
+              end
+            end
+          end
+        end
+      end
+    end
   end
 
   describe "capture_message" do


### PR DESCRIPTION
We're attempting to use the Plug provider for ExSentry, and we need a way to disable it in our dev environments.  This is one way to do it, but I'm open to other possible solutions.  What do you think?

Collaborating w/ @ringmaster