### PR TITLE
added ExSentry.LoggerBackend

### DIFF
--- a/lib/exsentry.ex
+++ b/lib/exsentry.ex
@@ -23,19 +23,64 @@ defmodule ExSentry do
             [applications: [:exsentry]]
           end
 
-  3. Optional: To configure the default ExSentry client, specify your
-     Sentry DSN in `config.exs`:
+  3. To configure the default ExSentry client, specify your Sentry DSN
+     in `config.exs`:
 
           config :exsentry, dsn: "your-dsn-here"
 
+     To turn ExSentry off for a particular `MIX_ENV`, set the Sentry
+     DSN to the empty string `""` in the appropriate config file.
 
-  ## Usage
 
-  ExSentry can be used as a manually-configured standalone client,
-  as a `config.exs`-configured OTP application,
-  or as a Plug in your webapp's plug stack (e.g., Phoenix router).
+  ## Getting Started
 
-  ### Standalone
+  Use `ExSentry.LoggerBackend` to send all `:error`-level log messages
+  to Sentry:
+
+      defmodule Myapp do
+        use Application
+
+        def start(_type, _args) do
+          Logger.add_backend(ExSentry.LoggerBackend)
+          # ...
+        end
+
+        # ...
+      end
+
+  Use `ExSentry.Plug` to capture all exceptions in a Plug pipeline:
+
+      # Phoenix example
+      defmodule Myapp.Router do
+        use Myapp.Web, :router
+        use ExSentry.Plug
+
+        pipeline :browser do
+          # ...
+
+
+      # pure Plug example
+      defmodule Myapp.Router do
+        use Plug.Router
+        use ExSentry.Plug
+
+        get "/" do
+          # ...
+
+  Use `ExSentry` by itself to send exception or message data to Sentry:
+
+      ExSentry.capture_message("Hello world!")
+
+      ExSentry.capture_exception(an_exception)
+
+      ExSentry.capture_exceptions fn ->
+        something_that_might_raise()
+      end
+
+
+  ## Standalone usage
+
+  ExSentry can be used as a manually-configured standalone client.
 
   Create a client process like this:
 
@@ -50,40 +95,6 @@ defmodule ExSentry do
       client |> ExSentry.capture_exceptions fn ->
         something_that_might_raise()
       end
-
-
-  ### OTP Application
-
-  If you've configured `config.exs` as described in the README:
-
-      config :exsentry, dsn: "your-dsn-here"
-
-  You can invoke ExSentry without explicitly creating a client:
-
-      ExSentry.capture_message("Hello world!")
-
-      ExSentry.capture_exception(an_exception)
-
-      ExSentry.capture_exceptions fn ->
-        something_that_might_raise()
-      end
-
-
-  ### Plug
-
-  ExSentry can be used as a Plug error handler, to automatically inform
-  Sentry of any exceptions encountered within your web application.
-
-  To use ExSentry as a Plug error handler, follow all configuration
-  instructions, then put `use ExSentry.Plug` wherever your Plug stack is
-  defined, for instance in `web/router.ex` in a Phoenix application:
-
-      defmodule MyApp.Router do
-        use MyApp.Web, :router
-        use ExSentry.Plug
-
-        pipeline :browser do
-        ...
 
 
   ## Authorship and License

--- a/lib/exsentry/logger_backend.ex
+++ b/lib/exsentry/logger_backend.ex
@@ -1,0 +1,89 @@
+defmodule ExSentry.LoggerBackend do
+  @moduledoc ~S"""
+  `ExSentry.LoggerBackend` is a backend for the Elixir `Logger` app.
+  It captures all log messages above a given severity level (default `:error`)
+  with `ExSentry.capture_message`.
+
+  ## Usage
+
+  1. Install the logger backend with:
+
+          Logger.add_backend(ExSentry.LoggerBackend)
+
+     or, in `mix.exs`:
+
+          # Warning! Removes other configured backends!
+          config :logger, backends: [ExSentry.LoggerBackend]
+
+  2. (Optional) Configure the log level with:
+
+          Logger.configure_backend(ExSentry.LoggerBackend, level: :warn)
+
+     or, in `mix.exs`:
+
+          config :exsentry, :logger_backend, level: :warn
+
+  ## Available configuration parameters
+
+  * `:level` - Sets log level to `level` and above.  Atom.
+  * `:log_levels` - Sets log levels specifically; supersedes `:level`.
+     List of atoms.
+  """
+
+  use GenEvent
+
+  defmodule State do
+    @moduledoc false
+
+    @levels %{
+      error: [:error],
+      warn:  [:error, :warn],
+      info:  [:error, :warn, :info],
+      debug: [:error, :warn, :info, :debug]
+    }
+
+    defstruct log_levels: @levels.error
+
+    def new(opts \\ []), do: %__MODULE__{} |> set(opts)
+
+    def set(%__MODULE__{}=state, opts) do
+      log_levels = opts[:log_levels] || @levels[opts[:level]] || state.log_levels
+      %{state | log_levels: log_levels}
+    end
+  end
+
+  @doc false
+  def init(_) do
+    {:ok, State.new(
+      level: get_config(:level),
+      log_levels: get_config(:log_levels),
+    )}
+  end
+
+  @doc false
+  def handle_call({:configure, opts}, %State{}=state) do
+    {:ok, :ok, State.set(state, opts)}
+  end
+
+  @doc false
+  def handle_event({level, _gl, {Logger, msg, _ts, _md}}, %State{}=state) do
+    ## The lack of "when node(gl) == node()" is deliberate.  I'd rather
+    ## ExSentry tend toward over-reporting rather than potentially miss
+    ## valuable crash information from another node.
+
+    if level in state.log_levels, do: ExSentry.capture_message(msg)
+
+    {:ok, state}
+  end
+
+  @doc false
+  def handle_event(_event, %State{}=state) do
+    {:ok, state}
+  end
+
+
+  defp get_config(key) do
+    Application.get_env(:exsentry, :logger_backend, []) |> Keyword.get(key)
+  end
+end
+


### PR DESCRIPTION
This PR adds `ExSentry.LoggerBackend`, which sends to Sentry log messages at or above a given severity.