### PR TITLE
added ExSentry.Plug whitelists

### DIFF
--- a/test/exsentry/plug_test.exs
+++ b/test/exsentry/plug_test.exs
@@ -13,5 +13,36 @@ defmodule ExSentry.PlugTest do
       end
     end
   end
+
+  defmodule NotFoundError do
+    defexception plug_status: 404, message: "not found"
+  end
+
+  describe "with_whitelists" do
+    it "respects :exception_whitelist" do
+      e = %NotFoundError{}
+      opts = [exception_whitelist: [NotFoundError]]
+      assert :whitelisted = ExSentry.Plug.with_whitelists opts, e, fn ->
+        assert false
+      end
+    end
+
+    it "respects :plug_status_whitelist" do
+      e = %NotFoundError{}
+      opts = [plug_status_whitelist: [404]]
+      assert :whitelisted = ExSentry.Plug.with_whitelists opts, e, fn ->
+        assert false
+      end
+    end
+
+    it "runs function otherwise" do
+      e = %NotFoundError{}
+      opts = [exception_whitelist: [ArgumentError],
+              plug_status_whitelist: [401]]
+      assert :cool = ExSentry.Plug.with_whitelists opts, e, fn ->
+        :cool
+      end
+    end
+  end
 end
 


### PR DESCRIPTION
This PR adds the `:exception_whitelist` and `:plug_status_whitelist` options to `ExSentry.Plug`, for ignoring certain types of exceptions.