### PR TITLE
added :otp_app config parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.7.0
+
+Simplified outgoing HTTP code by removing keepalive.
+
+
 0.6.3
 
 * Removed Timex dependency.

--- a/lib/exsentry.ex
+++ b/lib/exsentry.ex
@@ -20,7 +20,9 @@ defmodule ExSentry do
   3. Configure the default ExSentry client by specifying your Sentry DSN
      in `config.exs`:
 
-          config :exsentry, dsn: "your-dsn-here"
+          config :exsentry,
+            otp_app: :my_app,
+            dsn: "your-dsn-here"
 
      To turn ExSentry off for a particular `MIX_ENV`, set the Sentry
      DSN to the empty string `""` in the appropriate config file.
@@ -31,7 +33,7 @@ defmodule ExSentry do
   Use `ExSentry.LoggerBackend` to send all `:error`-level log messages
   to Sentry:
 
-      defmodule Myapp do
+      defmodule MyApp do
         use Application
 
         def start(_type, _args) do
@@ -45,8 +47,8 @@ defmodule ExSentry do
   Use `ExSentry.Plug` to capture all exceptions in a Plug pipeline:
 
       # Phoenix example
-      defmodule Myapp.Router do
-        use Myapp.Web, :router
+      defmodule MyApp.Router do
+        use MyApp.Web, :router
         use ExSentry.Plug
 
         pipeline :browser do
@@ -54,7 +56,7 @@ defmodule ExSentry do
 
 
       # pure Plug example
-      defmodule Myapp.Router do
+      defmodule MyApp.Router do
         use Plug.Router
         use ExSentry.Plug
 

--- a/lib/exsentry/client.ex
+++ b/lib/exsentry/client.ex
@@ -66,6 +66,10 @@ defmodule ExSentry.Client do
           port: fu.port,
           path: "/api/#{project_id}/store/"
         }
+        version = case Application.get_env(:exsentry, :otp_app) do
+          nil -> "0.0.0"
+          app -> ExSentry.Utils.version(app) || "0.0.0"
+        end
 
         {:ok, %State{
           dsn: dsn,

--- a/lib/exsentry/model/payload.ex
+++ b/lib/exsentry/model/payload.ex
@@ -6,6 +6,8 @@ defmodule ExSentry.Model.Payload do
 
   @derive [Poison.Encoder]
 
+  @otp_app Application.get_env(:exsentry, :otp_app)
+
   defstruct platform: "other",
             release: nil,
             modules: nil,
@@ -39,6 +41,10 @@ defmodule ExSentry.Model.Payload do
   @spec from_opts([atom: any]) :: map
   def from_opts(opts \\ []) do
     versions = ExSentry.Utils.versions
+    version = case @otp_app do
+      nil -> "0.0.0"
+      app -> ExSentry.Utils.version(app)
+    end
     now = ExSentry.Utils.datetime_now
 
     ## attributes
@@ -65,7 +71,7 @@ defmodule ExSentry.Model.Payload do
 
     %ExSentry.Model.Payload{
       platform: "other", ## no official love for Elixir yet
-      release: versions[:exsentry],
+      release: version,
       modules: versions,
 
       event_id: event_id,

--- a/lib/exsentry/model/payload.ex
+++ b/lib/exsentry/model/payload.ex
@@ -6,8 +6,6 @@ defmodule ExSentry.Model.Payload do
 
   @derive [Poison.Encoder]
 
-  @otp_app Application.get_env(:exsentry, :otp_app)
-
   defstruct platform: "other",
             release: nil,
             modules: nil,
@@ -41,7 +39,7 @@ defmodule ExSentry.Model.Payload do
   @spec from_opts([atom: any]) :: map
   def from_opts(opts \\ []) do
     versions = ExSentry.Utils.versions
-    version = case @otp_app do
+    version = case Application.get_env(:exsentry, :otp_app) do
       nil -> "0.0.0"
       app -> ExSentry.Utils.version(app)
     end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule ExSentry.Mixfile do
 
   def project do
     [app: :exsentry,
-     version: "0.6.3",
+     version: "0.7.0",
      elixir: "~> 1.1",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
@@ -39,7 +39,7 @@ defmodule ExSentry.Mixfile do
 
   defp deps do
     [
-      {:fuzzyurl, "~> 0.9.0"},
+      {:fuzzyurl, "~> 0.9 or ~> 1.0"},
       {:uuid, "~> 1.1"},
       {:hackney, "~> 1.4"},
       {:poison, "~> 1.5 or ~> 2.0"},

--- a/test/exsentry/client_test.exs
+++ b/test/exsentry/client_test.exs
@@ -4,9 +4,8 @@ defmodule ExSentry.ClientTest do
   doctest ExSentry.Client
 
   defp with_mock_http(fun) do
-    with_mock ExSentry.Sender, [
-      get_connection: fn (_) -> :pretend_this_is_a_conn_ref end,
-      send_request: fn (_conn_ref, _url, headers, payload) ->
+    with_mock :hackney, [
+      request: fn (_method, _url, headers, payload) ->
         assert([] != headers |> Enum.filter(fn ({k,_}) -> k == "X-Sentry-Auth" end))
         assert([] != headers |> Enum.filter(fn ({k,_}) -> k == "Content-Type" end))
         body = Poison.decode!(payload)

--- a/test/exsentry/integration_test.exs
+++ b/test/exsentry/integration_test.exs
@@ -7,7 +7,7 @@ defmodule ExSentry.IntegrationTest do
       request: fn (_method, _url, _headers, _payload) -> :ok end
     ] do
       fun.()
-      Process.sleep(300)
+      :timer.sleep(300)
       assert called :hackney.request(:_, :_, :_, :_)
     end
   end


### PR DESCRIPTION
This PR adds the `:otp_app` config parameter, which is used for selecting the `release` version to send with each Sentry request.

Example:

```
# config.exs
config :exsentry, otp_app: :my_app
```

Resolves #6.